### PR TITLE
Fix build issue

### DIFF
--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -334,8 +334,8 @@ associated_domains_fragment = "" if telegram_bundle_id not in official_bundle_id
 <array>
     <string>applinks:telegram.me</string>
     <string>applinks:t.me</string>
-    <strings>applinks:nicegram.app</strings>
-    <strings>applinks:yfqcuhfv.xyz</strings>
+    <string>applinks:nicegram.app</string>
+    <string>applinks:yfqcuhfv.xyz</string>
 </array>
 """
 


### PR DESCRIPTION
Fixes the following build error. Presumably `strings` is not a valid tag:

ERROR: While processing target "//Telegram:Telegram_entitlements", plutil failed (1) to convert "bazel-out/applebin_ios-ios_armv7-opt-ST-36ad1e8d6baf/bin/Telegram/TelegramEntitlements.entitlements" to xml.