### PR TITLE
Integrate FlickType Keyboard for Apple Watch

### DIFF
--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -376,6 +376,30 @@ plist_fragment(
     ])
 )
 
+watch_extension_app_id_fragment = """
+    <key>application-identifier</key>
+    <string>{telegram_team_id}.{telegram_bundle_id}.watchkitapp.watchkitextension</string>
+""".format(
+    telegram_team_id=telegram_team_id,
+    telegram_bundle_id=telegram_bundle_id
+)
+
+watch_extension_associated_domains_fragment = """
+<key>com.apple.developer.associated-domains</key>
+<array>
+    <string>applinks:nicegram.app</string>
+</array>
+"""
+
+plist_fragment(
+    name = "TelegramWatchEntitlements",
+    extension = "entitlements",
+    template = "".join([
+        watch_extension_app_id_fragment,
+        watch_extension_associated_domains_fragment,
+    ])
+)
+
 filegroup(
     name = "TelegramWatchExtensionResources",
     srcs = glob([
@@ -409,6 +433,7 @@ objc_library(
     srcs = glob([
         "Watch/Extension/**/*.m",
         "Watch/SSignalKit/**/*.m",
+        "Watch/FlickTypeKit/**/*.m",
         "Watch/Bridge/**/*.m",
         "Watch/WatchCommonWatch/**/*.m",
         "Watch/Extension/**/*.h",
@@ -537,6 +562,7 @@ watchos_extension(
         telegram_bundle_id = telegram_bundle_id,
     ),
     bundle_name = "TelegramWatchExtension",
+    entitlements = ":TelegramWatchEntitlements.entitlements",
     infoplists = [
         ":WatchExtensionInfoPlist",
         ":VersionInfoPlist",

--- a/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.h
+++ b/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.h
@@ -1,0 +1,42 @@
+//
+//  FlickTypeKit.h
+//  FlickTypeKit
+//
+//  Created by Kosta Eleftheriou on 5/3/21.
+//  Copyright © 2021 Kpaw. All rights reserved.
+//
+
+#import <WatchKit/WatchKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, FlickTypeMode) {
+    FlickTypeModeAsk,
+    FlickTypeModeAlways,
+    FlickTypeModeOff
+};
+
+typedef NS_ENUM(NSInteger, FlickTypeCompletionType) {
+    FlickTypeCompletionTypeDismiss,
+    FlickTypeCompletionTypeAction,
+};
+
+@interface FlickType : NSObject
+
+// eg "https://www.my-app.com/flicktype"
+@property (class) NSURL* returnURL;
+
+// Returns true if it was a FlickType response activity
++ (BOOL)handle:(NSUserActivity*)userActivity;
+
+@end
+
+@interface WKInterfaceController (FlickType)
+
+- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode completion:(void(^)(NSArray * __nullable results))completion; // results is nil if cancelled
+
+- (void)presentTextInputControllerWithSuggestionsForLanguage:(NSArray * __nullable (^ __nullable)(NSString *inputLanguage))suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode  flickType:(FlickTypeMode)flickTypeMode completion:(void(^)(NSArray * __nullable results))completion; // will never go straight to dictation because allows for switching input language
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.h
+++ b/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.h
@@ -23,19 +23,29 @@ typedef NS_ENUM(NSInteger, FlickTypeCompletionType) {
 
 @interface FlickType : NSObject
 
-// eg "https://www.my-app.com/flicktype"
+@property (class, readonly) NSString* sdkVersion;
+
+// eg "https://your.app.domain/flicktype"
 @property (class) NSURL* returnURL;
 
-// Returns true if it was a FlickType response activity
+// Returns true if `userActivity` was a FlickType response activity
 + (BOOL)handle:(NSUserActivity*)userActivity;
 
 @end
 
 @interface WKInterfaceController (FlickType)
 
-- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode completion:(void(^)(NSArray * __nullable results))completion; // results is nil if cancelled
+// Suggestion list, with `flickType` argument
+- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode completion:(void(^)(NSArray * __nullable results))completion;
 
-- (void)presentTextInputControllerWithSuggestionsForLanguage:(NSArray * __nullable (^ __nullable)(NSString *inputLanguage))suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode  flickType:(FlickTypeMode)flickTypeMode completion:(void(^)(NSArray * __nullable results))completion; // will never go straight to dictation because allows for switching input language
+// Suggestion list, with `flickType` and `startingText` arguments
+- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode startingText:(NSString *)startingText completion:(void(^)(NSArray * __nullable results))completion;
+
+// Suggestion handler, with `flickType` argument
+- (void)presentTextInputControllerWithSuggestionsForLanguage:(NSArray * __nullable (^ __nullable)(NSString *inputLanguage))suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode completion:(void(^)(NSArray * __nullable results))completion;
+
+// Suggestion handler, with `flickType` and `startingText` arguments
+- (void)presentTextInputControllerWithSuggestionsForLanguage:(NSArray * __nullable (^ __nullable)(NSString *inputLanguage))suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode startingText:(NSString *)startingText completion:(void(^)(NSArray * __nullable results))completion;
 
 @end
 

--- a/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.m
+++ b/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.m
@@ -1,0 +1,321 @@
+//
+//  FlickTypeKit.m
+//  FlickTypeKit
+//
+//  Created by Kosta Eleftheriou on 5/3/21.
+//  Copyright © 2021 Kpaw. All rights reserved.
+//
+
+#import "FlickTypeKit.h"
+#import <objc/runtime.h>
+
+typedef void (^CompletionBlock)(NSArray * __nullable results);
+typedef NSArray * __nullable (^SuggestionsBlock)(NSString *inputLanguage);
+
+struct TextInputInvocation {
+    NSArray<NSString*> * suggestions;
+    SuggestionsBlock suggestionsHandler;
+    WKTextInputMode inputMode;
+    FlickTypeMode flickTypeMode;
+    NSDictionary* flickTypeProperties;
+    NSString* startingText;
+    CompletionBlock completion;
+};
+
+typedef void (^InvocationCompletionHandler)(NSString*, FlickTypeCompletionType);
+
+static InvocationCompletionHandler completionHandler(struct TextInputInvocation invocation) {
+    return ^void(NSString* result, FlickTypeCompletionType completionType) { invocation.completion(@[result, @(completionType)]); };
+}
+
+@interface WKInterfaceController (FlickType_Private)
+- (void)alert:(NSString*)message;
+- (void)handlePresentTextInput:(struct TextInputInvocation)invocation;
+- (void)presentSystemInputController:(struct TextInputInvocation)invocation;
+- (void)presentFlickTypeOrIntermediateController:(struct TextInputInvocation)invocation;
+@end
+
+// These are to ensure we can call the original methods of the `WKInterfaceController` class when needed
+@interface WKInterfaceController (Original_Methods)
+- (void)presentWKTextInputControllerWithSuggestions:(NSArray *)suggestions allowedInputMode:(WKTextInputMode)inputMode completion:(CompletionBlock)completion;
+- (void)presentWKTextInputControllerWithSuggestionsForLanguage:(SuggestionsBlock)suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode completion:(CompletionBlock)completion;
+@end
+
+@implementation WKInterfaceController (FlickType)
+
+- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode  completion:(CompletionBlock)completion {
+    
+    // This source version of FlickTypeKit only supports watchOS 7 or later
+    if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion < 7) {
+        return [self presentWKTextInputControllerWithSuggestions:suggestions allowedInputMode:inputMode completion:completion];
+    }
+    
+    assert([NSThread isMainThread]);
+    struct TextInputInvocation invocation = {
+        .suggestions = suggestions,
+        .suggestionsHandler = nil,
+        .inputMode = inputMode,
+        .flickTypeMode = flickTypeMode,
+        .flickTypeProperties = @{},
+        .startingText = @"",
+        .completion = completion
+    };
+    [self handlePresentTextInput:invocation];
+}
+
+- (void)presentTextInputControllerWithSuggestionsForLanguage:(SuggestionsBlock)suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode completion:(CompletionBlock)completion {
+    
+    // This source version of FlickTypeKit only supports watchOS 7 or later
+    if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion < 7) {
+        return [self presentWKTextInputControllerWithSuggestionsForLanguage:suggestionsHandler allowedInputMode:inputMode completion:completion];
+    }
+    
+    assert([NSThread isMainThread]);
+    struct TextInputInvocation invocation = {
+        .suggestions = nil,
+        .suggestionsHandler = suggestionsHandler,
+        .inputMode = inputMode,
+        .flickTypeMode = flickTypeMode,
+        .flickTypeProperties = @{},
+        .startingText = @"",
+        .completion = completion
+    };
+    [self handlePresentTextInput:invocation];
+}
+
+@end
+
+struct ReturnHandler {
+    NSString* token;
+    InvocationCompletionHandler completion;
+};
+
+@interface FlickType (Private)
+
+@property (class, readonly) NSString* typeURL;
+@property (class) struct ReturnHandler returnHandler;
+@property (class) BOOL hasSwitchedFromFlickType;
+
+@end
+
+@implementation WKInterfaceController (FlickType_Private)
+
+- (void)handlePresentTextInput:(struct TextInputInvocation)invocation {
+    // You can only edit existing text with FlickType.
+    BOOL existingText = [invocation.startingText stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet].length > 0;
+    FlickTypeMode flickTypeMode = existingText ? FlickTypeModeAlways : invocation.flickTypeMode;
+  
+    // Don't force FlickType if the app is not known to be installed on the device
+    if (flickTypeMode == FlickTypeModeAlways && !FlickType.hasSwitchedFromFlickType) {
+        flickTypeMode = FlickTypeModeAsk;
+    }
+    
+    switch (flickTypeMode) {
+        case FlickTypeModeAsk:    [self presentSystemInputController:invocation]; break;
+        case FlickTypeModeAlways: [self presentFlickTypeOrIntermediateController:invocation]; break;
+        case FlickTypeModeOff:    [self presentSystemInputController:invocation]; break;
+    }
+}
+
+- (void)presentSystemInputController:(struct TextInputInvocation)invocation {
+  
+    NSString* flickTypeText = @"⌨︎\tFlickType\n\tKeyboard";
+  
+    void (^completionWrapper)(NSArray*) = ^void(NSArray* textInputControllerReturnedItems) {
+        if ([textInputControllerReturnedItems.firstObject isEqualToString:flickTypeText]) {
+            return [self presentFlickTypeOrIntermediateController:invocation];
+        }
+        invocation.completion(textInputControllerReturnedItems);
+    };
+
+    // Handle the 4 combinations of (list or handler) x (include flicktype or not)
+    if (invocation.suggestionsHandler != nil) {
+        SuggestionsBlock wrappedSuggestionsHandler = ^NSArray * __nullable (NSString *inputLanguage){
+            return [(invocation.flickTypeMode == FlickTypeModeOff ? @[] : @[flickTypeText]) arrayByAddingObjectsFromArray:invocation.suggestionsHandler(inputLanguage)];
+        };
+        [self presentWKTextInputControllerWithSuggestionsForLanguage:wrappedSuggestionsHandler allowedInputMode:invocation.inputMode completion:completionWrapper];
+    } else {
+        NSArray<NSString*>* suggestions = [(invocation.flickTypeMode == FlickTypeModeOff ? @[] : @[flickTypeText]) arrayByAddingObjectsFromArray:invocation.suggestions];
+        [self presentWKTextInputControllerWithSuggestions: suggestions allowedInputMode:invocation.inputMode completion:completionWrapper];
+    }
+}
+
+- (void)alert:(NSString*)message {
+    NSLog(@"⚠️ FlickTypeKit: %@", message);
+    [self presentAlertControllerWithTitle:@"⚠️\nFlickTypeKit" message:message preferredStyle: WKAlertControllerStyleAlert actions: @[
+        [WKAlertAction actionWithTitle:@"OK" style:WKAlertActionStyleDefault handler:^{}],
+    ]];
+}
+
+- (void)presentFlickTypeOrIntermediateController:(struct TextInputInvocation)invocation {
+
+    if (FlickType.returnURL == nil) { return [self alert:@"FlickType.returnURL is not set"]; }
+    if (![FlickType.returnURL.absoluteString hasPrefix:@"https://"]) { return [self alert:@"FlickType.returnURL must start with `https://`"]; }
+    
+    void (^switchToFlickType)(BOOL) = ^void(BOOL includeStartingText) {
+        NSString* token = [NSString stringWithFormat:@"%f", NSDate.timeIntervalSinceReferenceDate];
+        NSLog(@"token: %@", token);
+        struct ReturnHandler returnHandler = { .token = token, .completion = completionHandler(invocation) };
+        FlickType.returnHandler = returnHandler;
+        NSMutableDictionary* queryItems = [@{
+            @"token" : token,
+            @"returnURL" : FlickType.returnURL.absoluteString,
+            @"startingText" : includeStartingText ? invocation.startingText : @"",
+        } mutableCopy];
+        [queryItems addEntriesFromDictionary:invocation.flickTypeProperties];
+        NSURLComponents* urlComps = [NSURLComponents componentsWithString:FlickType.typeURL];
+        NSMutableArray* urlCompsQueryItems = [@[] mutableCopy];
+        [queryItems enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull value, BOOL * _Nonnull stop) {
+            [urlCompsQueryItems addObject:[NSURLQueryItem queryItemWithName:key value:value]];
+        }];
+        urlComps.queryItems = urlCompsQueryItems;
+        [WKExtension.sharedExtension openSystemURL:urlComps.URL];
+    };
+    
+    if (FlickType.hasSwitchedFromFlickType) {
+        switchToFlickType(YES); // YES: includeStartingText
+    } else {
+        NSURL* flickTypeAppStoreURL = [NSURL URLWithString:@"https://apps.apple.com/us/app/flicktype-keyboard/id1359485719"];
+        [self presentAlertControllerWithTitle:@"⌨️" message:@"Download “FlickType Keyboard” from the App Store?" preferredStyle:WKAlertControllerStyleAlert actions:@[
+            [WKAlertAction actionWithTitle:@"Download now" style:WKAlertActionStyleDefault handler:^{
+                [WKExtension.sharedExtension openSystemURL:flickTypeAppStoreURL];
+            }],
+            [WKAlertAction actionWithTitle:@"I already have it" style:WKAlertActionStyleDefault handler:^{
+                // Redact `startingText` until the first successful app-switch roundtrip, to prevent sensitive content from
+                // ever reaching our web server if watchOS implements opening a web browser when our app isn't installed.
+                // Regardless, our web server does not keep logs of any kind.
+                switchToFlickType(NO); // NO: do not includeStartingText
+            }],
+        ]];
+    }
+}
+
+@end
+
+// We use these because `self` might be some `WKInterfaceController` subclass that has overriden
+// `presentTextInputControllerWithSuggestions`, which would cause an infinite recursion if called like `[self presentTextInput...];`
+@implementation WKInterfaceController (Original_Methods)
+
+- (void)presentWKTextInputControllerWithSuggestions:(NSArray *)suggestions allowedInputMode:(WKTextInputMode)inputMode completion:(CompletionBlock)completion {
+    SEL selector = @selector(presentTextInputControllerWithSuggestions:allowedInputMode:completion:);
+    IMP imp = class_getMethodImplementation([WKInterfaceController class], selector);
+    void (*callableImp)(id, SEL, NSArray<NSString*> *, WKTextInputMode, CompletionBlock) = (typeof(callableImp)) imp;
+    callableImp(self, selector, suggestions, inputMode, completion);
+}
+
+- (void)presentWKTextInputControllerWithSuggestionsForLanguage:(SuggestionsBlock)suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode completion:(CompletionBlock)completion {
+    SEL selector = @selector(presentTextInputControllerWithSuggestionsForLanguage:allowedInputMode:completion:);
+    IMP imp = class_getMethodImplementation([WKInterfaceController class], selector);
+    void (*callableImp)(id, SEL, SuggestionsBlock, WKTextInputMode, CompletionBlock) = (typeof(callableImp)) imp;
+    callableImp(self, selector, suggestionsHandler, inputMode, completion);
+}
+
+@end
+
+
+@implementation FlickType
+
+static NSString* _typeURL = @"https://flicktype.com/type/";
+static NSURL* _returnURL = nil;
+static struct ReturnHandler _returnHandler;
+
++ (NSURL*)returnURL {
+    return _returnURL;
+}
+
++ (void)setReturnURL:(NSURL*)url {
+    _returnURL = url;
+}
+
++ (NSString*)typeURL {
+    return _typeURL;
+}
+
++ (struct ReturnHandler)returnHandler {
+    return _returnHandler;
+}
+
++ (void)setReturnHandler:(struct ReturnHandler)handler {
+    _returnHandler = handler;
+}
+
++ (BOOL)hasSwitchedFromFlickType {
+    return [NSUserDefaults.standardUserDefaults boolForKey:@"FlickType_HAS_SWITCHED_FROM_MAIN_APP"];
+}
+
++ (void)setHasSwitchedFromFlickType:(BOOL)value {
+    [NSUserDefaults.standardUserDefaults setBool:value forKey:@"FlickType_HAS_SWITCHED_FROM_MAIN_APP"];
+}
+
++ (BOOL)handle:(NSUserActivity*)userActivity {
+    NSLog(@"handle userActivity %@", userActivity);
+    // TODO: main thread check?
+    
+    void (^alert)(NSString*) = ^void(NSString* message) {
+        [WKExtension.sharedExtension.visibleInterfaceController alert:message];
+    };
+        
+    // Get URL components from the incoming user activity
+    if (![userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) { return false; }
+    NSURL* incomingURL = userActivity.webpageURL;
+    if (incomingURL == nil) { return false; }
+    NSURLComponents* components = [NSURLComponents componentsWithURL:incomingURL resolvingAgainstBaseURL:YES];
+    if (components == nil) { return false; }
+    
+    if (_returnURL == nil) {
+        alert(@"Return URL is not set");
+        return false;
+    }
+    
+    if (![incomingURL.absoluteString hasPrefix:_returnURL.absoluteString]) { return false; }
+    
+    if (_returnHandler.token == nil || _returnHandler.completion == nil) {
+        alert(@"Unexpected activity");
+        return true;
+    }
+    
+    NSString* expectedToken = _returnHandler.token;
+    InvocationCompletionHandler completionHandler = _returnHandler.completion;
+    
+    if (components.queryItems == nil) {
+        alert(@"No query items");
+        return true;
+    }
+    
+    NSMutableDictionary<NSString*,NSURLQueryItem*>* params = [@{} mutableCopy];
+    for (NSURLQueryItem* queryItem in components.queryItems) {
+        params[queryItem.name] = queryItem;
+    }
+
+    NSString* token = params[@"token"].value;
+    if (token == nil) {
+        alert(@"No token param");
+        return true;
+    }
+    
+    if (![token isEqualToString:expectedToken]) {
+        alert(@"Unexpected token");
+        return true;
+    }
+    
+    NSString* text = params[@"text"].value;
+    if (text == nil) {
+        alert(@"No text param");
+        return true;
+    }
+    
+    FlickTypeCompletionType completionType = FlickTypeCompletionTypeAction;
+    // App versions < 2020.8 did not supply a completion type on return
+    if ([params[@"completion"].value isEqualToString:@"0"]) {
+        completionType = FlickTypeCompletionTypeDismiss;
+    }
+    
+    [self setHasSwitchedFromFlickType:YES];
+    _returnHandler.token = nil;
+    _returnHandler.completion = nil;
+    completionHandler(text, completionType);
+    
+    return true;
+}
+
+@end

--- a/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.m
+++ b/Telegram/Watch/Extension/FlickTypeKit/FlickTypeKit.m
@@ -43,7 +43,12 @@ static InvocationCompletionHandler completionHandler(struct TextInputInvocation 
 
 @implementation WKInterfaceController (FlickType)
 
+// Wrapper for default `startingText` value
 - (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode  completion:(CompletionBlock)completion {
+    [self presentTextInputControllerWithSuggestions:suggestions allowedInputMode:inputMode flickType:flickTypeMode startingText:@"" completion:completion];
+}
+
+- (void)presentTextInputControllerWithSuggestions:(nullable NSArray<NSString*> *)suggestions allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode startingText:(NSString *)startingText completion:(CompletionBlock)completion {
     
     // This source version of FlickTypeKit only supports watchOS 7 or later
     if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion < 7) {
@@ -56,14 +61,19 @@ static InvocationCompletionHandler completionHandler(struct TextInputInvocation 
         .suggestionsHandler = nil,
         .inputMode = inputMode,
         .flickTypeMode = flickTypeMode,
-        .flickTypeProperties = @{},
-        .startingText = @"",
+        .flickTypeProperties = @{}, // TODO: currently not implemented in Objective-C version
+        .startingText = startingText,
         .completion = completion
     };
     [self handlePresentTextInput:invocation];
 }
 
+// Wrapper for default `startingText` value
 - (void)presentTextInputControllerWithSuggestionsForLanguage:(SuggestionsBlock)suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode completion:(CompletionBlock)completion {
+    [self presentTextInputControllerWithSuggestionsForLanguage:suggestionsHandler allowedInputMode:inputMode flickType:flickTypeMode startingText:@"" completion:completion];
+}
+
+- (void)presentTextInputControllerWithSuggestionsForLanguage:(SuggestionsBlock)suggestionsHandler allowedInputMode:(WKTextInputMode)inputMode flickType:(FlickTypeMode)flickTypeMode startingText:(NSString *)startingText completion:(CompletionBlock)completion {
     
     // This source version of FlickTypeKit only supports watchOS 7 or later
     if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion < 7) {
@@ -77,7 +87,7 @@ static InvocationCompletionHandler completionHandler(struct TextInputInvocation 
         .inputMode = inputMode,
         .flickTypeMode = flickTypeMode,
         .flickTypeProperties = @{},
-        .startingText = @"",
+        .startingText = startingText,
         .completion = completion
     };
     [self handlePresentTextInput:invocation];
@@ -154,7 +164,6 @@ struct ReturnHandler {
     
     void (^switchToFlickType)(BOOL) = ^void(BOOL includeStartingText) {
         NSString* token = [NSString stringWithFormat:@"%f", NSDate.timeIntervalSinceReferenceDate];
-        NSLog(@"token: %@", token);
         struct ReturnHandler returnHandler = { .token = token, .completion = completionHandler(invocation) };
         FlickType.returnHandler = returnHandler;
         NSMutableDictionary* queryItems = [@{
@@ -215,7 +224,10 @@ struct ReturnHandler {
 
 @implementation FlickType
 
-static NSString* _typeURL = @"https://flicktype.com/type/";
++ (NSString*)sdkVersion {
+    return @"2.0.0/objc";
+}
+
 static NSURL* _returnURL = nil;
 static struct ReturnHandler _returnHandler;
 
@@ -228,7 +240,7 @@ static struct ReturnHandler _returnHandler;
 }
 
 + (NSString*)typeURL {
-    return _typeURL;
+    return @"https://flicktype.com/type/";
 }
 
 + (struct ReturnHandler)returnHandler {
@@ -248,7 +260,7 @@ static struct ReturnHandler _returnHandler;
 }
 
 + (BOOL)handle:(NSUserActivity*)userActivity {
-    NSLog(@"handle userActivity %@", userActivity);
+    NSLog(@"FlickTypeKit: handle userActivity %@", userActivity);
     // TODO: main thread check?
     
     void (^alert)(NSString*) = ^void(NSString* message) {

--- a/Telegram/Watch/Extension/TGExtensionDelegate.m
+++ b/Telegram/Watch/Extension/TGExtensionDelegate.m
@@ -4,6 +4,7 @@
 #import "TGBridgeClient.h"
 #import "TGDateUtils.h"
 #import "TGNeoChatsController.h"
+#import "FlickTypeKit/FlickTypeKit.h"
 
 @interface TGExtensionDelegate ()
 {
@@ -112,6 +113,20 @@
 + (instancetype)instance
 {
     return (TGExtensionDelegate *)[[WKExtension sharedExtension] delegate];
+}
+
+@end
+
+@implementation TGExtensionDelegate (FlickType)
+
+- (void)applicationDidFinishLaunching
+{
+    FlickType.returnURL = [NSURL URLWithString:@"https://nicegram.app/flicktype/"];
+}
+
+- (void)handleActivity:(NSUserActivity *)userActivity
+{
+    if ([FlickType handle:userActivity]) { return; }
 }
 
 @end

--- a/Telegram/Watch/Extension/TGInterfaceController.m
+++ b/Telegram/Watch/Extension/TGInterfaceController.m
@@ -1,5 +1,6 @@
 #import "TGInterfaceController.h"
 #import "WKInterfaceTable+TGDataDrivenTable.h"
+#import "FlickTypeKit/FlickTypeKit.h"
 
 @interface TGInterfaceControllerContext : NSObject
 
@@ -123,7 +124,7 @@
 {
     [self _willPresentController];
     
-    [super presentTextInputControllerWithSuggestions:suggestions allowedInputMode:inputMode completion:completion];
+    [super presentTextInputControllerWithSuggestions:suggestions allowedInputMode:inputMode flickType:FlickTypeModeAsk completion:completion];
 }
 
 - (void)performInterfaceUpdate:(void (^)(bool))updates

--- a/submodules/DebugSettingsUI/BUILD
+++ b/submodules/DebugSettingsUI/BUILD
@@ -1,12 +1,14 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
+NGDEPS = ["//Nicegram/NGData:NGData"]
+
 swift_library(
     name = "DebugSettingsUI",
     module_name = "DebugSettingsUI",
     srcs = glob([
 		"Sources/**/*.swift",
     ]),
-    deps = [
+    deps = NGDEPS + [
         "//submodules/SSignalKit/SwiftSignalKit:SwiftSignalKit",
         "//submodules/Display:Display",
         "//submodules/Postbox:Postbox",


### PR DESCRIPTION
Adds the required plumbing for Nicegram to work with the FlickType app. When using the “Reply” option on Apple Watch, FlickType will appear as an alternative input option.

Since all third-party dependencies seem to be included as code in the project, I added the FlickType.m and header file from the [FlickType source](https://github.com/FlickType/FlickTypeKit/tree/objc), and made the necessary changes to the BUILD file. If there’s a better way to integrate in this project, please let me know.

Note that for the FlickType app to be able to return the user’s input text back to your app using universal links, this PR depends on this [website change](https://github.com/nicegram/nicegram.github.io/pull/34).

![IMG_1297](https://user-images.githubusercontent.com/19254337/118350472-ca67cc80-b50b-11eb-9fb3-d515ca1c647c.PNG)
![IMG_1300](https://user-images.githubusercontent.com/19254337/118350528-1d418400-b50c-11eb-8745-64e014a7d788.PNG)
![IMG_1301](https://user-images.githubusercontent.com/19254337/118350531-203c7480-b50c-11eb-91ea-bcd98d320b62.PNG)
